### PR TITLE
Upgrade DJango version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-compressor==2.3
 django-dotenv==1.4.2
 django-extensions==2.2.5
 django-pyscss==2.0.2
-django==2.2.8
+django==2.2.9
 idna==2.8                 # via requests
 lxml==4.4.2
 newrelic==5.4.0.132


### PR DESCRIPTION
This update applies a security patch for a CVE in DJango for versions 2.2.8 or prior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-it/air.mozilla.org/73)
<!-- Reviewable:end -->
